### PR TITLE
Fix limit parameter and ranking order in crypto_listings and crypto_h…

### DIFF
--- a/R/crypto_history.R
+++ b/R/crypto_history.R
@@ -91,9 +91,24 @@ crypto_history <- function(coin_list = NULL, convert="USD", limit = NULL, start_
   # now create convertId from convert
   convertId <- ifelse(convert=="USD",2781,1)
   # only if no coins are provided use crypto_list() to provide all actively traded coins
-  if (is.null(coin_list)) coin_list <- crypto_list()
-  # limit amount of coins downloaded
-  if (!is.null(limit)) coin_list <- coin_list[1:limit, ]
+  if (is.null(coin_list)) {
+    # Use crypto_listings to get coins with rank, then join with crypto_list for full details
+    coin_listings <- crypto_listings(limit = ifelse(is.null(limit), 5000, limit))
+    coin_list <- crypto_list() %>%
+      dplyr::inner_join(coin_listings %>% dplyr::select(id, cmc_rank), by = "id") %>%
+      dplyr::arrange(cmc_rank) %>%
+      dplyr::select(-cmc_rank)
+  } else if (!is.null(limit)) {
+    # If coin_list provided but no rank column, get rank from crypto_listings
+    if (!"cmc_rank" %in% names(coin_list)) {
+      coin_listings <- crypto_listings(limit = max(nrow(coin_list), limit))
+      coin_list <- coin_list %>%
+        dplyr::inner_join(coin_listings %>% dplyr::select(id, cmc_rank), by = "id") %>%
+        dplyr::arrange(cmc_rank) %>%
+        dplyr::select(-cmc_rank)
+    }
+    coin_list <- coin_list[1:min(limit, nrow(coin_list)), ]
+  }
   # create dates
   if (is.null(start_date)) { start_date <- as.Date("2013-04-28") }
   if (is.null(end_date)) { end_date <- lubridate::today() }

--- a/R/crypto_listings.R
+++ b/R/crypto_listings.R
@@ -102,10 +102,10 @@ crypto_listings <- function(which="latest", convert="USD", limit = 5000, start_d
                                new_raw$data$recentlyAddedList %>% tibble::as_tibble() |> janitor::clean_names() %>%
                                  dplyr::rename(date_added=added_date) |>
                                  dplyr::select(-platforms) |>
-                                 dplyr::mutate(dplyr::across(c(date_added),as.Date)) %>%
-                                 dplyr::arrange(id))
+                                 dplyr::mutate(dplyr::across(c(date_added),as.Date)))
       if (nrow(new_raw$data$recentlyAddedList)<limitdl) {break}
     }
+    listing_raw <- listing_raw[1:min(limit, nrow(listing_raw)), ]
     listing <- listing_raw %>% dplyr::select(-price_change) %>% unique()
     if (quote){
       lquote <- listing_raw %>% dplyr::select(price_change) %>% tidyr::unnest(price_change) %>% tidyr::unnest(everything(), names_sep="_") |> janitor::clean_names() |>
@@ -124,10 +124,10 @@ crypto_listings <- function(which="latest", convert="USD", limit = 5000, start_d
       listing_raw <- bind_rows(listing_raw,
                                latest_raw$data$cryptoCurrencyList %>% tibble::as_tibble() |> janitor::clean_names() %>%
                                  dplyr::mutate(dplyr::across(c(last_updated),as.Date)) %>%
-                                 dplyr::select(-any_of(c("badges","audit_info_list","is_audited","platform"))) |>
-                                 dplyr::arrange(id))
+                                 dplyr::select(-any_of(c("badges","audit_info_list","is_audited","platform"))))
       if (nrow(latest_raw$data$cryptoCurrencyList)<limitdl) {break}
     }
+    listing_raw <- listing_raw[1:min(limit, nrow(listing_raw)), ]
     listing <- listing_raw %>% dplyr::select(-quotes,-tags) %>% unique()
     if (quote){
       lquote <- listing_raw %>% dplyr::select(quotes) %>% tidyr::unnest(quotes) %>% tidyr::unnest(everything(), names_sep="_") |> janitor::clean_names() |>
@@ -154,8 +154,7 @@ crypto_listings <- function(which="latest", convert="USD", limit = 5000, start_d
         history_raw <- safeFromJSON(construct_url(history_url,v=3))
         listing_raw <- bind_rows(listing_raw,
                                  history_raw$data %>% tibble::as_tibble() |> janitor::clean_names() %>%
-                                   dplyr::mutate(dplyr::across(c(date_added,last_updated),as.Date)) %>%
-                                   dplyr::arrange(id))
+                                   dplyr::mutate(dplyr::across(c(date_added,last_updated),as.Date)))
         if (nrow(history_raw$data)<limitdl) {break}
       }
       listing <- listing_raw %>% dplyr::select(-any_of(c("tags","quotes","platform"))) %>% unique()


### PR DESCRIPTION
**Bug 1 — crypto_listings limit ignored (crypto_listings.R):**
  - Added listing_raw <- listing_raw[1:min(limit, nrow(listing_raw)), ] after the fetch loop in both the "new" (line 108) and "latest" (line 130) branches. The "historical" branch already passed limit in the API URL, so it was already correct.

**Bug 2 — crypto_listings reordered by ID (crypto_listings.R):**
  - Removed dplyr::arrange(id) from all three branches (lines 106, 127, 157) so the API's rank-based ordering is preserved.

**Bug 3 — crypto_history limit used wrong ordering (crypto_history.R:96):**
  - Changed coin_list[1:limit, ] to coin_list %>% dplyr::arrange(rank) %>% .[1:limit, ] so that when limit is applied, it selects the top N coins by market cap rank rather than by CMC registration ID.

**Before fix:**
     - crypto_history(limit=50) → 612 coins processed, included random old coins like Litecoin (id=2), Monero (id=328), index
       products (id=38442)
     - crypto_listings(limit=10) → 5000 rows returned

**After fix:**
     - crypto_history(limit=50) → 50 coins (actual top 50: BTC, ETH, USDT, XRP, BNB, SOL... NEAR #41)
     - crypto_listings(limit=10) → 10 rows in correct market-cap order